### PR TITLE
Expo project launcher updated

### DIFF
--- a/bin/nativeup
+++ b/bin/nativeup
@@ -8,7 +8,7 @@ if [ "$1" = "cli" ]; then
   cd $2
   git init .
 elif [ "$1" = "expo" ]; then
-  expo init $2 -t blank --yarn
+  yarn create expo-app $2 -t blank
   cd $2
 else
   echo "Unknown project type; enter one of: cli, expo"


### PR DESCRIPTION
Hi,

I did a little update on line 11: 

**yarn create expo-app $2 -t blank**

using the new Expo way to create a new project.

The new Expo uses npm to install dependencies if you use npx and yarn if you use this last package manager to create a new project.
